### PR TITLE
Handle missing keyframe error

### DIFF
--- a/source/core/ui/view/video/WebCodecView.js
+++ b/source/core/ui/view/video/WebCodecView.js
@@ -232,6 +232,7 @@ class WebCodecView extends CanvasView {
                         codedWidth: this.width,
                         codedHeight:this.height,
                     });
+                    this.seenKeyframe = false;
                 }
                 const bitmap = await createImageBitmap(videoFrame);
                 try {
@@ -255,6 +256,7 @@ class WebCodecView extends CanvasView {
                 codedWidth: this.width,
                 codedHeight: this.height,
             });
+            this.seenKeyframe = false;
             this.codecConfigured = true;
         }catch (ex) {
             this.elementDiv.remove(); // remove reserved div element

--- a/source/core/ui/view/video/WebCodecView.js
+++ b/source/core/ui/view/video/WebCodecView.js
@@ -384,16 +384,13 @@ class WebCodecView extends CanvasView {
                 type: key ? 'key' : 'delta',
                 data: frameData
             });
-            
-            try {
-                this.videoDecoder.decode(chunk);
-            } catch (e) {
-                if (e.message.includes("A key frame is required after configure() or flush().")) {
-                    console.warn('Missing keyframe');
-                } else {
-                    throw e;
-                }
+
+            if (!this.seenKeyframe && chunk.type !== "key") {
+                return
             }
+            
+            this.videoDecoder.decode(chunk);
+
         } else {
             console.warn('decoder has not been initialized yet');
         }

--- a/source/core/ui/view/video/WebCodecView.js
+++ b/source/core/ui/view/video/WebCodecView.js
@@ -384,6 +384,16 @@ class WebCodecView extends CanvasView {
                 type: key ? 'key' : 'delta',
                 data: frameData
             });
+            
+            try {
+                this.videoDecoder.decode(chunk);
+            } catch (e) {
+                if (e.message.includes("A key frame is required after configure() or flush().")) {
+                    console.warn('Missing keyframe');
+                } else {
+                    throw e;
+                }
+            }
             this.videoDecoder.decode(chunk);
         } else {
             console.warn('decoder has not been initialized yet');

--- a/source/core/ui/view/video/WebCodecView.js
+++ b/source/core/ui/view/video/WebCodecView.js
@@ -394,7 +394,6 @@ class WebCodecView extends CanvasView {
                     throw e;
                 }
             }
-            this.videoDecoder.decode(chunk);
         } else {
             console.warn('decoder has not been initialized yet');
         }


### PR DESCRIPTION
With the update to modern worker import syntax I updated the webtak v2 plugin to webpack v5 since v4 cannot read the new  syntax. The default error handling behavior is different in v5. If there is a missing keyframe (which isn't an error we want to throw since it's a common occurrence) it now will display an error modal. This change skips over the decode call entirely if a key frame hasn't been received. 


Additionally, a new key frame is required after a call to `configure()` so after those calls I set `seenKeyframe` to `false` so we don't decode until we receive the next key frame.