### PR TITLE
Revert CesiumView.js scaling

### DIFF
--- a/source/core/ui/view/map/CesiumView.js
+++ b/source/core/ui/view/map/CesiumView.js
@@ -485,7 +485,7 @@ class CesiumView extends MapView {
                 // description: undefined,
                 // position: undefined,
                 image: properties.icon,
-                scaleByDistance: new NearFarScalar(1000, 0.5, 100000, 0.3),
+                scaleByDistance: new NearFarScalar(1000, 1.0, 10e6, 0.0),
                 // alignedAxis: (this.viewer.camera.pitch < -Math.PI / 4) && properties.allowBillboardRotation ? Cartesian3.UNIT_Z : Cartesian3.ZERO, // Z means rotation is from north
                 // rotation: rot,
                 // horizontalOrigin: HorizontalOrigin.LEFT,


### PR DESCRIPTION
Single commit reverting scaleByDistance back to (1000, 1.0, 10e6, 0.0) in Cesiumview. Change was originally made to adjust size of .svg icons, but moving back to .png and the original scale was correct.