### PR TITLE
Replay data synchronizer remove datasource bugs

### DIFF
--- a/source/core/timesync/replay/DataSynchronizer.replay.js
+++ b/source/core/timesync/replay/DataSynchronizer.replay.js
@@ -378,7 +378,6 @@ class DataSynchronizerReplay {
                     startTimestamp: this.getStartTimeAsTimestamp(),
                     endTimestamp: this.getEndTimeAsTimestamp()
                 }).then(async () => {
-                    await this.disconnect();
                     this.timeChanged();
                     this.onRemovedDataSource(dataSource.id);
                 });

--- a/source/core/timesync/replay/DataSynchronizer.replay.worker.js
+++ b/source/core/timesync/replay/DataSynchronizer.replay.worker.js
@@ -81,7 +81,6 @@ async function handleMessage(event) {
                 dataSynchronizerAlgo.startTimestamp = event.data.startTimestamp;
                 dataSynchronizerAlgo.endTimestamp = event.data.endTimestamp;
             }
-            reset();
         } else if (event.data.message === 'current-time') {
             data = dataSynchronizerAlgo.getCurrentTimestamp();
         } else if (event.data.message === 'reset') {


### PR DESCRIPTION
When calling `removeDatasource` on the `DataSynchronizerReplay` class we were making a call that disconnected _all_ datasources from the synchronizer, not just the one passed to the method. This meant that in a client such as the webtak plugin when we toggled one visualization off it stopped the connections of all visualizations. 

Additionally, the `removeDataSource` method publishes a `remove` event which is handled by the data synchronizer replay worker which stops the data synchronizer altogether.

Now we only disconnect the datasource that's passed to the `removeDatasource` method and we keep the synchronizer working so that the streaming of connected datasources continues.

Test
- Start a node and configure a system driver database with historical data that has at least 2 visualizations
- Start the webtak plugin, open it, and launch the osh plugin
- Enter playback mode
- Start playback (default start timestamp should work)
- Verify that visualizations are displayed
- Toggle one of the visualizations off
- Verify that the correct visualization is removed from the map, that the other visualizations persist and continue updating