### PR TITLE
Resolve infinite loop when removing a datasource from the realtime data synchronizer

### DIFF
--- a/source/core/datasource/TimeSeries.realtime.datasource.js
+++ b/source/core/datasource/TimeSeries.realtime.datasource.js
@@ -216,9 +216,6 @@ class TimeSeriesRealtimeDatasource extends DataSource {
     }
 
     async removeDataSynchronizer() {
-        if(this.dataSynchronizer) {
-            await this.dataSynchronizer.removeDataSource(this);
-        }
         this.dataSynchronizer = undefined;
         // remove datasynchronizer
         // restore datasource topic

--- a/source/core/datasource/TimeSeries.replay.datasource.js
+++ b/source/core/datasource/TimeSeries.replay.datasource.js
@@ -211,10 +211,6 @@ class TimeSeriesReplayDatasource extends DataSource {
     }
 
     async removeDataSynchronizer() {
-        // ISSUE: this causing loop because this.dataSynchronizer.removeDataSource(this); is calling this method
-        // if(this.dataSynchronizer) {
-        //     await this.dataSynchronizer.removeDataSource(this);
-        // }
         this.init = undefined;
         this.dataSynchronizer = undefined;
         return this.checkInit();


### PR DESCRIPTION
The `TimeSeriesRealtimeDatasource.removeDataSynchronizer` method was calling `DataSynchronizerRealtime.removeDataSource` method which then called `TimeSeriesRealtimeDatasource.removeDataSynchronizer` which then called the `DataSynchronizerRealtime.removeDataSource` method...ok you get the picture.

This bug was called out in the `TimeSeriesReplayDatasource` class so removed the offending cal as was done there.

Test
- I verified the fix with the webtak plugin when i refactored realtime mode to use the data synchronizer but i later learned that we weren't using the data synchronizer on purpose. So testing this now will be annoying. I think it's an obvious enough change to review logically with the knowledge that it did work as expected when i was using the data synchronizer in realtime mode