### PR TITLE
Add condition when clearing polyline location properties

### DIFF
--- a/source/core/ui/layer/PolylineLayer.js
+++ b/source/core/ui/layer/PolylineLayer.js
@@ -170,7 +170,10 @@ class PolylineLayer extends Layer {
 
 	clear() {
 		const currentProps = this.getCurrentProps();
-		currentProps.locations = [];
+		
+		if (currentProps) {
+			currentProps.locations = [];
+		}
 	}
 }
 


### PR DESCRIPTION
When starting the webtak plugin we call the discovery service and create the necessary layers for the results. It's not guaranteed that these layers will receive data. For example if i have a system with only historical data and i never play it back. This causes a problem because if the View is ever reset (either when the broadcast channel receives a time changed or closed error) it makes a call to clear all the layers. The layer clear previously assumed that it had received data so it would crash when trying to access a property that was never set (propsById). The fix adds an if condition to check if the property exists before accessing it. If it doesn't exist there is nothing to clear.

Tested by running a db file which i will provide in replay mode. It had 5 minutes of data. After 5 minutes i would see the error as a webpack modal. This is because the socket is closed after 5 minutes. With the fix you will not see the error and they replay driver should loop without error